### PR TITLE
Member retrieve

### DIFF
--- a/http/http-client.private.env.json
+++ b/http/http-client.private.env.json
@@ -1,6 +1,6 @@
 {
   "local": {
     "host": "localhost:8080",
-    "token" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJqaHNvbmcyNTgwMTIzIiwiYXV0aCI6IlJPTEVfT1JHQU5JWkVSLFJPTEVfVVNFUiIsImlkIjoxMiwiZXhwIjoxNjg1OTQzNjAxfQ.tqtP7BoImxcDAb0TeUtkN7ieBZCCqxYrlt350uIqmHQ"
+    "token" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJqaHNvbmcyNTgwMTI0NTYiLCJhdXRoIjoiUk9MRV9QQVJUSUNJUEFOVCxST0xFX1VTRVIiLCJpZCI6MTcsImV4cCI6MTY4NTg5Mzg2MH0.kkQHQSY4TWd9wqFhPhywtqDdBuNqd-4w8cUvvCQQnhA"
   }
 }

--- a/http/member.http
+++ b/http/member.http
@@ -39,11 +39,11 @@ POST {{host}}/members/login
 Content-Type: application/json
 
 {
-  "identification" : "jhsong2580123",
+  "identification" : "jhsong258012456",
   "password" : "New1234!!"
 }
 
 ###
-GET {{host}}/members/test
+GET {{host}}/members
 Content-Type: application/json
 Authorization: Bearer {{token}}

--- a/readmeSource/HISTORY.md
+++ b/readmeSource/HISTORY.md
@@ -26,3 +26,11 @@
     - PARTICIPANT : 참여자 권한. 참여자 등록이 된 사용자는 권한을 가지게 된다 
     - ORGANIZER : 주최자 권한. 주최자 등록이 된 사용자는 권한을 가지게 된다
   - Role은 GrantedAuthorityDefaults 에 의해서, ROLE_ 라는 prefix를 가지고 토큰에 저장된다
+
+---
+### member_retrieve
+- 사용자 정보 조회 기능을 구현한다 
+  1. Authorization Header 내 Jwt Token을 통해 사용자 ID를 조회한다
+     - Argument Resolver를 통해 획득한다
+  2. 사용자 ID 기반 사용자 정보, 참여자 정보, 주최자 정보를 가져온다
+     - MemberFacadeService를 통해 접근하며, 순서대로 사용자 정보, 참여자 정보, 주최자 정보를 가져온다. 

--- a/src/main/java/youth/week6/argumentResolver/MemberId.java
+++ b/src/main/java/youth/week6/argumentResolver/MemberId.java
@@ -1,0 +1,12 @@
+package youth.week6.argumentResolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MemberId {
+
+}

--- a/src/main/java/youth/week6/argumentResolver/MemberIdResolver.java
+++ b/src/main/java/youth/week6/argumentResolver/MemberIdResolver.java
@@ -1,0 +1,44 @@
+package youth.week6.argumentResolver;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import youth.week6.member.jwt.service.JwtTokenProvider;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class MemberIdResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterAnnotation(MemberId.class) != null
+            && parameter.getParameterType().equals(Long.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+        NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+
+        String jwtToken = resolveToken(webRequest);
+
+        return jwtTokenProvider.getMemberId(jwtToken);
+    }
+
+    private String resolveToken(WebRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/youth/week6/configuration/WebConfig.java
+++ b/src/main/java/youth/week6/configuration/WebConfig.java
@@ -1,0 +1,21 @@
+package youth.week6.configuration;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import youth.week6.argumentResolver.MemberIdResolver;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final MemberIdResolver memberIdResolver;
+
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+        argumentResolvers.add(memberIdResolver);
+    }
+}

--- a/src/main/java/youth/week6/configuration/security/SecurityConfig.java
+++ b/src/main/java/youth/week6/configuration/security/SecurityConfig.java
@@ -3,6 +3,7 @@ package youth.week6.configuration.security;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.core.GrantedAuthorityDefaults;
@@ -30,8 +31,10 @@ public class SecurityConfig {
             .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
             .and()
             .authorizeRequests()
-            .antMatchers("/members/login").permitAll()
-            .antMatchers("/**").hasRole(MemberRoles.ORGANIZER.name())
+            .antMatchers("/members/login").permitAll() // Login All Permit
+            .antMatchers(HttpMethod.POST, "/members/organizers").permitAll() // Member Join All Permit
+            .antMatchers(HttpMethod.POST, "/members/participants").permitAll() // Member Join All Permit
+            .antMatchers("/**").hasRole(MemberRoles.USER.name())
             .anyRequest().authenticated()
             .and()
             .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/youth/week6/member/controller/MemberController.java
+++ b/src/main/java/youth/week6/member/controller/MemberController.java
@@ -8,23 +8,28 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import youth.week6.argumentResolver.MemberId;
 import youth.week6.member.dto.request.LoginRequestDto;
 import youth.week6.member.dto.request.OrganizerMemberJoinRequestDto;
 import youth.week6.member.dto.request.ParticipantMemberJoinRequestDto;
+import youth.week6.member.dto.response.MemberDetailResponseDto;
 import youth.week6.member.dto.response.MemberJoinResponseDto;
 import youth.week6.member.jwt.dto.TokenInfo;
-import youth.week6.member.mapper.MemberJoinRequestDtoToJoinDtoMapper;
-import youth.week6.member.mapper.OrganizerJoinRequestDtoToJoinDtoMapper;
-import youth.week6.member.mapper.ParticipantJoinRequestDtoToJoinDtoMapper;
+import youth.week6.member.controller.mapper.DtosToMemberDetailResponseDtoMapper;
+import youth.week6.member.controller.mapper.MemberJoinRequestDtoToJoinDtoMapper;
+import youth.week6.member.controller.mapper.OrganizerJoinRequestDtoToJoinDtoMapper;
+import youth.week6.member.controller.mapper.ParticipantJoinRequestDtoToJoinDtoMapper;
 import youth.week6.member.member.dto.MemberJoinDto;
 import youth.week6.member.organizer.dto.OrganizerJoinDto;
 import youth.week6.member.participant.dto.ParticipantJoinDto;
 import youth.week6.member.service.LoginFacadeService;
 import youth.week6.member.service.MemberFacadeService;
+import youth.week6.member.service.dto.MemberDetailDto;
 
 @RestController
 @RequestMapping("/members")
@@ -36,7 +41,7 @@ public class MemberController {
     private final MemberJoinRequestDtoToJoinDtoMapper memberJoinDtoMapper;
     private final OrganizerJoinRequestDtoToJoinDtoMapper organizerJoinDtoMapper;
     private final ParticipantJoinRequestDtoToJoinDtoMapper participantJoinDtoMapper;
-
+    private final DtosToMemberDetailResponseDtoMapper detailResponseDtoMapper;
     @PostMapping("/participants")
     public ResponseEntity<?> join(
         @Validated @RequestBody ParticipantMemberJoinRequestDto participantMemberJoinRequestDto,
@@ -105,5 +110,18 @@ public class MemberController {
             loginRequestDto.getPassword());
 
         return ResponseEntity.ok(tokenInfo.getAccessToken());
+    }
+
+    @GetMapping()
+    public ResponseEntity<?> retrieveMember (@MemberId Long memberId){
+        MemberDetailDto memberDetailDto = memberFacadeService.get(memberId);
+
+        MemberDetailResponseDto memberDetailResponseDto = detailResponseDtoMapper.to(
+            memberDetailDto.getMemberDto(),
+            memberDetailDto.getParticipantDto(),
+            memberDetailDto.getOrganizerDto()
+        );
+
+        return ResponseEntity.ok(memberDetailResponseDto);
     }
 }

--- a/src/main/java/youth/week6/member/controller/mapper/DtosToMemberDetailResponseDtoMapper.java
+++ b/src/main/java/youth/week6/member/controller/mapper/DtosToMemberDetailResponseDtoMapper.java
@@ -1,0 +1,70 @@
+package youth.week6.member.controller.mapper;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.springframework.util.ObjectUtils;
+import youth.week6.member.dto.response.AllergenResponseDto;
+import youth.week6.member.dto.response.MemberDetailResponseDto;
+import youth.week6.member.dto.response.MemberResponseDto;
+import youth.week6.member.dto.response.OrganizerResponseDto;
+import youth.week6.member.dto.response.ParticipantResponseDto;
+import youth.week6.member.member.dto.MemberDto;
+import youth.week6.member.organizer.dto.OrganizerDto;
+import youth.week6.member.participant.dto.ParticipantDto;
+
+@Mapper(componentModel = "spring")
+public interface DtosToMemberDetailResponseDtoMapper {
+
+    @Mapping(expression = "java(getMemberResponseDto(memberDto))", target = "member")
+    @Mapping(expression = "java(getParticipantResponseDto(participantDto))", target = "participant")
+    @Mapping(expression = "java(getOrganizerResponseDto(organizerDto))", target = "organizer")
+    MemberDetailResponseDto to(
+        MemberDto memberDto,
+        ParticipantDto participantDto,
+        OrganizerDto organizerDto
+    );
+
+
+
+
+    default ParticipantResponseDto getParticipantResponseDto(ParticipantDto participantDto) {
+        if(ObjectUtils.isEmpty(participantDto)) {
+            return null;
+        }
+
+        List<AllergenResponseDto> allergenResponseDtos = participantDto.getAllergens().stream()
+            .map(
+                allergenDto -> new AllergenResponseDto(allergenDto.getId(), allergenDto.getName()))
+            .collect(Collectors.toList());
+
+        return new ParticipantResponseDto(
+            participantDto.getId(),
+            participantDto.getDescription(),
+            allergenResponseDtos
+        );
+    }
+
+    default OrganizerResponseDto getOrganizerResponseDto(OrganizerDto organizerDto) {
+        if(ObjectUtils.isEmpty(organizerDto)) {
+            return null;
+        }
+
+        return new OrganizerResponseDto(
+            organizerDto.getId(),
+            organizerDto.getBelong()
+        );
+    }
+
+    default MemberResponseDto getMemberResponseDto(MemberDto memberDto) {
+        return new MemberResponseDto(
+            memberDto.getId(),
+            memberDto.getName(),
+            memberDto.getBirthDate(),
+            memberDto.getSex(),
+            memberDto.getEmail(),
+            memberDto.getIdentification()
+        );
+    }
+}

--- a/src/main/java/youth/week6/member/controller/mapper/MemberJoinRequestDtoToJoinDtoMapper.java
+++ b/src/main/java/youth/week6/member/controller/mapper/MemberJoinRequestDtoToJoinDtoMapper.java
@@ -1,4 +1,4 @@
-package youth.week6.member.mapper;
+package youth.week6.member.controller.mapper;
 
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;

--- a/src/main/java/youth/week6/member/controller/mapper/OrganizerJoinRequestDtoToJoinDtoMapper.java
+++ b/src/main/java/youth/week6/member/controller/mapper/OrganizerJoinRequestDtoToJoinDtoMapper.java
@@ -1,9 +1,7 @@
-package youth.week6.member.mapper;
+package youth.week6.member.controller.mapper;
 
 import org.mapstruct.Mapper;
-import youth.week6.member.dto.request.MemberJoinRequestDto;
 import youth.week6.member.dto.request.OrganizerJoinRequestDto;
-import youth.week6.member.member.dto.MemberJoinDto;
 import youth.week6.member.organizer.dto.OrganizerJoinDto;
 
 @Mapper(componentModel = "spring")

--- a/src/main/java/youth/week6/member/controller/mapper/ParticipantJoinRequestDtoToJoinDtoMapper.java
+++ b/src/main/java/youth/week6/member/controller/mapper/ParticipantJoinRequestDtoToJoinDtoMapper.java
@@ -1,9 +1,7 @@
-package youth.week6.member.mapper;
+package youth.week6.member.controller.mapper;
 
 import org.mapstruct.Mapper;
-import youth.week6.member.dto.request.OrganizerJoinRequestDto;
 import youth.week6.member.dto.request.ParticipantJoinRequestDto;
-import youth.week6.member.organizer.dto.OrganizerJoinDto;
 import youth.week6.member.participant.dto.ParticipantJoinDto;
 
 @Mapper(componentModel = "spring")

--- a/src/main/java/youth/week6/member/dto/request/LoginRequestDto.java
+++ b/src/main/java/youth/week6/member/dto/request/LoginRequestDto.java
@@ -2,11 +2,13 @@ package youth.week6.member.dto.request;
 
 import javax.validation.constraints.NotEmpty;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor // Constructor For Acceptance Test - MemberControllerTest
 public class LoginRequestDto {
     @NotEmpty
     private String identification;

--- a/src/main/java/youth/week6/member/dto/response/AllergenResponseDto.java
+++ b/src/main/java/youth/week6/member/dto/response/AllergenResponseDto.java
@@ -1,0 +1,14 @@
+package youth.week6.member.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class AllergenResponseDto {
+    private final Long id;
+    private final String name;
+
+    public AllergenResponseDto(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+}

--- a/src/main/java/youth/week6/member/dto/response/MemberDetailResponseDto.java
+++ b/src/main/java/youth/week6/member/dto/response/MemberDetailResponseDto.java
@@ -1,0 +1,23 @@
+package youth.week6.member.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MemberDetailResponseDto {
+
+    private final MemberResponseDto member;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final ParticipantResponseDto participant;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final OrganizerResponseDto organizer;
+
+    @Builder
+    public MemberDetailResponseDto(MemberResponseDto member, ParticipantResponseDto participant,
+        OrganizerResponseDto organizer) {
+        this.member = member;
+        this.participant = participant;
+        this.organizer = organizer;
+    }
+}

--- a/src/main/java/youth/week6/member/dto/response/MemberResponseDto.java
+++ b/src/main/java/youth/week6/member/dto/response/MemberResponseDto.java
@@ -1,0 +1,28 @@
+package youth.week6.member.dto.response;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import youth.week6.member.member.entity.Sex;
+
+@Getter
+public class MemberResponseDto {
+
+    private final Long id;
+    private final String name;
+    private final LocalDateTime birthDate;
+    private final Sex sex;
+    private final String email;
+    private final String identification;
+
+    @Builder
+    public MemberResponseDto(Long id, String name, LocalDateTime birthDate, Sex sex, String email,
+        String identification) {
+        this.id = id;
+        this.name = name;
+        this.birthDate = birthDate;
+        this.sex = sex;
+        this.email = email;
+        this.identification = identification;
+    }
+}

--- a/src/main/java/youth/week6/member/dto/response/OrganizerResponseDto.java
+++ b/src/main/java/youth/week6/member/dto/response/OrganizerResponseDto.java
@@ -1,0 +1,16 @@
+package youth.week6.member.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class OrganizerResponseDto {
+    private final Long id;
+    private final String belong;
+
+    @Builder
+    public OrganizerResponseDto(Long id, String belong) {
+        this.id = id;
+        this.belong = belong;
+    }
+}

--- a/src/main/java/youth/week6/member/dto/response/ParticipantResponseDto.java
+++ b/src/main/java/youth/week6/member/dto/response/ParticipantResponseDto.java
@@ -1,0 +1,17 @@
+package youth.week6.member.dto.response;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class ParticipantResponseDto {
+    private final Long id;
+    private final String description;
+    private final List<AllergenResponseDto> allergens;
+
+    public ParticipantResponseDto(Long id, String description, List<AllergenResponseDto> allergens) {
+        this.id = id;
+        this.description = description;
+        this.allergens = allergens;
+    }
+}

--- a/src/main/java/youth/week6/member/member/service/MemberService.java
+++ b/src/main/java/youth/week6/member/member/service/MemberService.java
@@ -52,11 +52,22 @@ public class MemberService {
     private Members saveMembersByMemberJoinDto(MemberJoinDto memberJoinDto) {
         Members members = Members.from(memberJoinDto);
 
-        try{
+        try {
             membersRepository.save(members);
-        }catch(DataIntegrityViolationException e){
+        } catch (DataIntegrityViolationException e) {
             throw new IllegalArgumentException("duplicated identification join request");
         }
         return members;
+    }
+
+    @Transactional(readOnly = true)
+    public MemberDto get(long memberId) {
+        Members members = membersRepository.findById(memberId)
+            .orElseThrow(
+                () -> new IllegalArgumentException(
+                    "there is no member info with " + memberId)
+            );
+
+        return dtoMapper.to(members);
     }
 }

--- a/src/main/java/youth/week6/member/organizer/service/OrganizerService.java
+++ b/src/main/java/youth/week6/member/organizer/service/OrganizerService.java
@@ -23,4 +23,14 @@ public class OrganizerService {
         return new OrganizerDto(organizers.getId(), organizerJoinDto.getBelong());
     }
 
+    @Transactional(readOnly = true)
+    public OrganizerDto get(long organizerId) {
+        Organizers organizers = organizersRepository.findById(organizerId)
+            .orElseThrow(
+                () -> new IllegalArgumentException(
+                    "there is no organizer info with " + organizerId)
+            );
+
+        return new OrganizerDto(organizers.getId(), organizers.getBelong());
+    }
 }

--- a/src/main/java/youth/week6/member/participant/service/ParticipantService.java
+++ b/src/main/java/youth/week6/member/participant/service/ParticipantService.java
@@ -31,4 +31,15 @@ public class ParticipantService {
 
         return dtoMapper.to(participants);
     }
+
+    @Transactional(readOnly = true)
+    public ParticipantDto get(long participantId) {
+        Participants participants = participantsRepository.findById(participantId)
+            .orElseThrow(
+                () -> new IllegalArgumentException(
+                    "there is no participant info with " + participantId)
+            );
+
+        return dtoMapper.to(participants);
+    }
 }

--- a/src/main/java/youth/week6/member/service/MemberFacadeService.java
+++ b/src/main/java/youth/week6/member/service/MemberFacadeService.java
@@ -12,6 +12,7 @@ import youth.week6.member.organizer.service.OrganizerService;
 import youth.week6.member.participant.dto.ParticipantDto;
 import youth.week6.member.participant.dto.ParticipantJoinDto;
 import youth.week6.member.participant.service.ParticipantService;
+import youth.week6.member.service.dto.MemberDetailDto;
 
 @Service
 @RequiredArgsConstructor
@@ -35,5 +36,17 @@ public class MemberFacadeService {
         MemberDto memberDto = memberService.joinOrganizers(memberJoinDto, organizerDto.getId());
 
         return memberDto.getId();
+    }
+
+    @Transactional(readOnly = true)
+    public MemberDetailDto get(long memberId) {
+        MemberDto memberDto = memberService.get(memberId);
+        ParticipantDto participantDto =
+            memberDto.getParticipantsId() != null ? participantService.get(
+                memberDto.getParticipantsId()) : null;
+        OrganizerDto organizerDto = memberDto.getOrganizerId() != null ? organizerService.get(
+            memberDto.getOrganizerId()) : null;
+
+        return new MemberDetailDto(memberDto, participantDto, organizerDto);
     }
 }

--- a/src/main/java/youth/week6/member/service/dto/MemberDetailDto.java
+++ b/src/main/java/youth/week6/member/service/dto/MemberDetailDto.java
@@ -1,0 +1,20 @@
+package youth.week6.member.service.dto;
+
+import lombok.Getter;
+import youth.week6.member.member.dto.MemberDto;
+import youth.week6.member.organizer.dto.OrganizerDto;
+import youth.week6.member.participant.dto.ParticipantDto;
+
+@Getter
+public class MemberDetailDto {
+    private final MemberDto memberDto;
+    private final ParticipantDto participantDto;
+    private final OrganizerDto organizerDto;
+
+    public MemberDetailDto(MemberDto memberDto, ParticipantDto participantDto,
+        OrganizerDto organizerDto) {
+        this.memberDto = memberDto;
+        this.participantDto = participantDto;
+        this.organizerDto = organizerDto;
+    }
+}

--- a/src/test/java/youth/week6/member/controller/MemberControllerTest.java
+++ b/src/test/java/youth/week6/member/controller/MemberControllerTest.java
@@ -1,17 +1,27 @@
 package youth.week6.member.controller;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static youth.week6.testFixture.AllergensFixture.BEEF;
 import static youth.week6.testFixture.AllergensFixture.MILK;
+import static youth.week6.testFixture.MemberFixture.사용자정보_정상입력;
+import static youth.week6.testFixture.OrganizerFixture.주최자정보_정상입력;
+import static youth.week6.testFixture.ParticipantFixture.참여자정보_정상입력;
+import static youth.week6.testUtils.acceptiontesetUtils.assertionUtils.MemberAcceptanceTestAssertionUtils.주최자정보_확인됨;
 import static youth.week6.testUtils.acceptiontesetUtils.assertionUtils.MemberAcceptanceTestAssertionUtils.참여자_회원가입_확인됨;
+import static youth.week6.testUtils.acceptiontesetUtils.assertionUtils.MemberAcceptanceTestAssertionUtils.참여자정보_확인됨;
 import static youth.week6.testUtils.acceptiontesetUtils.assertionUtils.MemberAcceptanceTestAssertionUtils.회원가입_중복지원_에러발생;
+import static youth.week6.testUtils.acceptiontesetUtils.assertionUtils.MemberAcceptanceTestAssertionUtils.회원정보_확인됨;
+import static youth.week6.testUtils.acceptiontesetUtils.sendUtils.MemberAcceptanceTestSendUtils.로그인을통한_JWT토큰획득;
 import static youth.week6.testUtils.acceptiontesetUtils.sendUtils.MemberAcceptanceTestSendUtils.주최자_회원가입_요청;
 import static youth.week6.testUtils.acceptiontesetUtils.sendUtils.MemberAcceptanceTestSendUtils.참여자_회원가입_요청;
+import static youth.week6.testUtils.acceptiontesetUtils.sendUtils.MemberAcceptanceTestSendUtils.회원정보_조회요청;
 
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import youth.week6.member.dto.request.LoginRequestDto;
 import youth.week6.member.dto.request.MemberJoinRequestDto;
 import youth.week6.member.dto.request.OrganizerJoinRequestDto;
 import youth.week6.member.dto.request.OrganizerMemberJoinRequestDto;
@@ -19,34 +29,33 @@ import youth.week6.member.dto.request.ParticipantJoinRequestDto;
 import youth.week6.member.dto.request.ParticipantMemberJoinRequestDto;
 import youth.week6.member.participant.entity.Allergens;
 import youth.week6.testFixture.AllergensFixture;
-import youth.week6.testFixture.MemberFixture;
-import youth.week6.testFixture.OrganizerFixture;
-import youth.week6.testFixture.ParticipantFixture;
 import youth.week6.testUtils.SpringBootTestHelper;
 
 class MemberControllerTest extends SpringBootTestHelper {
 
-    Map<AllergensFixture, Allergens> allergens;
+    private Map<AllergensFixture, Allergens> allergens;
+    private MemberJoinRequestDto 사용자_정보 = 사용자정보_정상입력.회원가입_사용자_요청전문();
+
+    private ParticipantJoinRequestDto 참여자_정보;
+    private OrganizerJoinRequestDto 주최자_정보 = 주최자정보_정상입력.회원가입_주최자_요청전문();
 
     @BeforeEach
     public void init() {
         super.init();
         super.savedAllergens();
         allergens = super.findAllAllergens();
+
+        참여자_정보 = 참여자정보_정상입력.회원가입_참여자_요청전문(
+            allergens.get(BEEF).getId(),
+            allergens.get(MILK).getId()
+        );
     }
 
     @Test
     public void 참여자_회원가입() {
 
         String 예상_사용자_데이터베이스_아이디값 = "1";
-
         //given
-        MemberJoinRequestDto 사용자_정보 = MemberFixture.사용자정보_정상입력.회원가입_사용자_요청전문();
-
-        ParticipantJoinRequestDto 참여자_정보 = ParticipantFixture.참여자정보_정상입력.회원가입_참여자_요청전문(
-            allergens.get(BEEF).getId(),
-            allergens.get(MILK).getId()
-        );
         ParticipantMemberJoinRequestDto 요청전문 = new ParticipantMemberJoinRequestDto(
             사용자_정보, 참여자_정보);
 
@@ -61,8 +70,6 @@ class MemberControllerTest extends SpringBootTestHelper {
     public void 주최자_회원가입() {
         String 예상_사용자_데이터베이스_아이디값 = "1";
         //given
-        MemberJoinRequestDto 사용자_정보 = MemberFixture.사용자정보_정상입력.회원가입_사용자_요청전문();
-        OrganizerJoinRequestDto 주최자_정보 = OrganizerFixture.주최자정보_정상입력.회원가입_주최자_요청전문();
         OrganizerMemberJoinRequestDto 요청전문 = new OrganizerMemberJoinRequestDto(
             사용자_정보, 주최자_정보);
 
@@ -70,14 +77,54 @@ class MemberControllerTest extends SpringBootTestHelper {
         ExtractableResponse<Response> 주최자_회원가입_요청_response = 주최자_회원가입_요청(요청전문);
 
         //then
-        참여자_회원가입_확인됨(주최자_회원가입_요청_response, 예상_사용자_데이터베이스_아이디값);
+        assertAll(
+            () -> 참여자_회원가입_확인됨(주최자_회원가입_요청_response, 예상_사용자_데이터베이스_아이디값)
+        );
+
     }
 
     @Test
+    public void 참여자_정보조회 (){
+        //given
+        ParticipantMemberJoinRequestDto 요청전문 = new ParticipantMemberJoinRequestDto(
+            사용자_정보, 참여자_정보);
+        참여자_회원가입_요청(요청전문);
+        String JWT_토큰 = 로그인을통한_JWT토큰획득(
+            new LoginRequestDto(사용자_정보.getIdentification(), 사용자_정보.getPassword()));
+
+        //when
+        ExtractableResponse<Response> 회원정보_조회요청_response = 회원정보_조회요청(JWT_토큰);
+
+        //then
+        assertAll(
+            () -> 회원정보_확인됨(회원정보_조회요청_response, 사용자_정보),
+            () -> 참여자정보_확인됨(회원정보_조회요청_response, 참여자_정보)
+        );
+    }
+
+    @Test
+    public void 주최자_정보조회 (){
+        //given
+        OrganizerMemberJoinRequestDto 요청전문 = new OrganizerMemberJoinRequestDto(
+            사용자_정보, 주최자_정보);
+        주최자_회원가입_요청(요청전문);
+        String JWT_토큰 = 로그인을통한_JWT토큰획득(
+            new LoginRequestDto(사용자_정보.getIdentification(), 사용자_정보.getPassword()));
+
+        //when
+        ExtractableResponse<Response> 회원정보_조회요청_response = 회원정보_조회요청(JWT_토큰);
+
+        //then
+        assertAll(
+            () -> 회원정보_확인됨(회원정보_조회요청_response, 사용자_정보),
+            () -> 주최자정보_확인됨(회원정보_조회요청_response, 주최자_정보)
+        );
+    }
+    @Test
     public void 중복_회원가입 (){
         //given
-        MemberJoinRequestDto 사용자_정보 = MemberFixture.사용자정보_정상입력.회원가입_사용자_요청전문();
-        OrganizerJoinRequestDto 주최자_정보 = OrganizerFixture.주최자정보_정상입력.회원가입_주최자_요청전문();
+        MemberJoinRequestDto 사용자_정보 = 사용자정보_정상입력.회원가입_사용자_요청전문();
+        OrganizerJoinRequestDto 주최자_정보 = 주최자정보_정상입력.회원가입_주최자_요청전문();
         OrganizerMemberJoinRequestDto 요청전문 = new OrganizerMemberJoinRequestDto(
             사용자_정보, 주최자_정보);
         주최자_회원가입_요청(요청전문);
@@ -88,4 +135,5 @@ class MemberControllerTest extends SpringBootTestHelper {
         //then
         회원가입_중복지원_에러발생(주최자_회원가입_요청_response);
     }
+
 }

--- a/src/test/java/youth/week6/testUtils/acceptiontesetUtils/assertionUtils/MemberAcceptanceTestAssertionUtils.java
+++ b/src/test/java/youth/week6/testUtils/acceptiontesetUtils/assertionUtils/MemberAcceptanceTestAssertionUtils.java
@@ -6,6 +6,10 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.springframework.http.HttpStatus;
+import youth.week6.member.dto.request.MemberJoinRequestDto;
+import youth.week6.member.dto.request.OrganizerJoinRequestDto;
+import youth.week6.member.dto.request.ParticipantJoinRequestDto;
+import youth.week6.member.dto.response.AllergenResponseDto;
 
 public class MemberAcceptanceTestAssertionUtils {
 
@@ -19,6 +23,35 @@ public class MemberAcceptanceTestAssertionUtils {
     public static void 회원가입_중복지원_에러발생(ExtractableResponse<Response> 회원가입_요청_response) {
         assertAll(
             () -> assertThat(회원가입_요청_response.statusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value())
+        );
+    }
+
+    public static void 회원정보_확인됨(ExtractableResponse<Response> 회원정보_조회요청_response, MemberJoinRequestDto 사용자_정보) {
+        assertAll(
+            () -> assertThat(회원정보_조회요청_response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+            () -> assertThat(회원정보_조회요청_response.jsonPath().get("member.identification").toString()).isEqualTo(사용자_정보.getIdentification()),
+            () -> assertThat(회원정보_조회요청_response.jsonPath().get("member.sex").toString()).isEqualTo(사용자_정보.getSex().name()),
+            () -> assertThat(회원정보_조회요청_response.jsonPath().get("member.name").toString()).isEqualTo(사용자_정보.getName()),
+            () -> assertThat(회원정보_조회요청_response.jsonPath().get("member.email").toString()).isEqualTo(사용자_정보.getEmail())
+        );
+    }
+
+    public static void 주최자정보_확인됨(ExtractableResponse<Response> 회원정보_조회요청_response,
+        OrganizerJoinRequestDto 주최자_정보) {
+        assertAll(
+            () -> assertThat(회원정보_조회요청_response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+            () -> assertThat(회원정보_조회요청_response.jsonPath().get("organizer.belong").toString()).isEqualTo(주최자_정보.getBelong())
+        );
+    }
+
+    public static void 참여자정보_확인됨(ExtractableResponse<Response> 회원정보_조회요청_response,
+        ParticipantJoinRequestDto 참여자_정보) {
+        assertAll(
+            () -> assertThat(회원정보_조회요청_response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+            () -> assertThat(회원정보_조회요청_response.jsonPath().get("participant.description").toString()).isEqualTo(참여자_정보.getDescription()),
+            () -> assertThat(회원정보_조회요청_response.jsonPath().getList("participant.allergens", AllergenResponseDto.class))
+                .extracting("id")
+                .containsExactlyInAnyOrderElementsOf(참여자_정보.getAllergens())
         );
     }
 }

--- a/src/test/java/youth/week6/testUtils/acceptiontesetUtils/sendUtils/MemberAcceptanceTestSendUtils.java
+++ b/src/test/java/youth/week6/testUtils/acceptiontesetUtils/sendUtils/MemberAcceptanceTestSendUtils.java
@@ -3,9 +3,11 @@ package youth.week6.testUtils.acceptiontesetUtils.sendUtils;
 import static youth.week6.testUtils.SnakeCaseObjectMapper.요청전문_snake_case_변경;
 
 import io.restassured.RestAssured;
+import io.restassured.http.Header;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.springframework.http.MediaType;
+import youth.week6.member.dto.request.LoginRequestDto;
 import youth.week6.member.dto.request.OrganizerMemberJoinRequestDto;
 import youth.week6.member.dto.request.ParticipantMemberJoinRequestDto;
 
@@ -31,6 +33,30 @@ public class MemberAcceptanceTestSendUtils {
             .body(요청전문_snake_case_변경)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .when().post("/members/organizers")
+            .then().log().all()
+            .extract();
+    }
+
+    public static String 로그인을통한_JWT토큰획득(LoginRequestDto 요청전문) {
+        String 요청전문_snake_case_변경 = 요청전문_snake_case_변경(요청전문);
+
+        ExtractableResponse<Response> 로그인결과 = RestAssured
+            .given().log().all()
+            .body(요청전문_snake_case_변경)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when().post("/members/login")
+            .then().log().all()
+            .extract();
+
+        return 로그인결과.body().asString();
+    }
+
+    public static ExtractableResponse<Response> 회원정보_조회요청(String JWT토큰) {
+        return RestAssured
+            .given().log().all()
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .header(new Header("Authorization", "Bearer " + JWT토큰))
+            .when().get("/members")
             .then().log().all()
             .extract();
     }


### PR DESCRIPTION
### member_retrieve
- 사용자 정보 조회 기능을 구현한다 
  1. Authorization Header 내 Jwt Token을 통해 사용자 ID를 조회한다
     - Argument Resolver를 통해 획득한다
  2. 사용자 ID 기반 사용자 정보, 참여자 정보, 주최자 정보를 가져온다
     - MemberFacadeService를 통해 접근하며, 순서대로 사용자 정보, 참여자 정보, 주최자 정보를 가져온다. 